### PR TITLE
Fixing bug that timeout and retry count need to be int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - fixing bug with parameter type for retry count and timeout (0.0.11)
  - first release of urlchecker module with container, tests, and brief documentation (0.0.1)
  - dummy release for pypi (0.0.0)
 

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -125,12 +125,14 @@ def get_parser():
     check.add_argument(
         "--retry-count",
         help="retry count upon failure (defaults to 2, one retry).",
+        type=int,
         default=2,
     )
 
     check.add_argument(
         "--timeout",
         help="timeout (seconds) to provide to the requests library (defaults to 5)",
+        type=int,
         default=5,
     )
 

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.1"
+__version__ = "0.0.11"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This is a quick fix that the retry count and timeout parameters need to be integers. It works fine with the default honored (ints) or provided as ints directly to the function, but parsed from the command line it comes as a string. 

Signed-off-by: vsoch <vsochat@stanford.edu>