### PR TITLE
adding docker deploy for quay.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches_ignore: []
+  release:
+    types: [published, created, edited]
 
 jobs:
   testing-docker:
@@ -10,4 +12,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2      
       - name: Build container image
-        run: docker build -t urlstechie .
+        run: |
+          docker build -t quay.io/urlstechie/urlchecker .
+          DOCKER_TAG=$(docker run quay.io/urlstechie/urlchecker --version)
+          printf "Docker Tag is ${DOCKER_TAG}\n"
+          echo "::set-env name=DOCKER_TAG::${DOCKER_TAG}"
+      - name: Docker login
+        env:
+          docker_user: ${{ secrets.DOCKER_USERNAME }}
+          docker_pass: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          docker login -u="${docker_user}" -p="${docker_pass}" quay.io
+      - name: Push containers
+        run: |
+          docker tag quay.io/urlstechie/urlchecker:latest "quay.io/urlstechie/urlchecker:${DOCKER_TAG}"
+          docker push quay.io/urlstechie/urlchecker:latest
+          docker push "quay.io/urlstechie/urlchecker:${DOCKER_TAG}"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /code
 ENV PATH /opt/conda/bin:${PATH}
 ENV LANG C.UTF-8
 ENV SHELL /bin/bash
-RUN /bin/bash -c "install_packages wget bzip2 ca-certificates git && \
+RUN apt-get update && \
+    /bin/bash -c "install_packages wget bzip2 ca-certificates git && \
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda3-latest-Linux-x86_64.sh && \


### PR DESCRIPTION
This is an approach I'm slightly more comfortable with - quay.io lets you create permission specific tokens, so it's less risky than Docker Hub. If this doesn't work we still could give the GitHub package registry a try, but I don't think many people are using it yet.

Note that I have pull_request set as a trigger to test, but before merge we will just want to do this on release.

Signed-off-by: vsoch <vsochat@stanford.edu>