### PR TITLE
removing unused file variable in urlproc.check_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - removing unused file variable (0.0.13)
  - adding support for csv export (0.0.12)
  - fixing bug with parameter type for retry count and timeout (0.0.11)
  - first release of urlchecker module with container, tests, and brief documentation (0.0.1)

--- a/tests/test_urlproc.py
+++ b/tests/test_urlproc.py
@@ -13,4 +13,4 @@ def test_check_urls(file):
     """
     check_results = {"failed": [], "passed": []}
     urls = collect_links_from_file(file)
-    check_urls(file, urls, check_results=check_results)
+    check_urls(urls, check_results=check_results)

--- a/urlchecker/core/check.py
+++ b/urlchecker/core/check.py
@@ -106,7 +106,7 @@ def check_files(
         # if some links are found, check them
         if urls:
             print("\n", file_name, "\n", "-" * len(file_name))
-            urlproc.check_urls(file_name, urls, check_results, retry_count, timeout)
+            urlproc.check_urls(urls, check_results, retry_count, timeout)
 
         # if no urls are found, mention it if required
         else:

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -111,12 +111,11 @@ def get_user_agent():
     return random.choice(agents)
 
 
-def check_urls(file, urls, check_results, retry_count=1, timeout=5):
+def check_urls(urls, check_results, retry_count=1, timeout=5):
     """
     Check urls extracted from a certain file and print the checks results.
 
     Args:
-        - file           (str) : path to file.
         - urls          (list) : list of urls to check.
         - check_results (list) : a list containing a list of succesfully checked links and errenous links.
         - retry_count    (int) : a number of retries to issue (defaults to 1, no retry).

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This PR will remove an unused variable from urlproc.check_urls. We aren't doing any significant changes so criteria for merge is just tests passing. I stumbled on this because I want to use the function to just check urls, and I realized it doesn't need a file! 

Signed-off-by: vsoch <vsochat@stanford.edu>