### PR TITLE
removing unecessary boolean parsing in check.py

### DIFF
--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -16,26 +16,6 @@ from urlchecker.logger import print_success, print_failure
 logger = logging.getLogger('urlchecker')
 
 
-def str2bool(str_bool):
-    """
-    Convert str input to boolean
-
-    Args:
-        - str_bool (str) : boolean variable as an str.
-
-    Returns
-        bool
-    """
-    if isinstance(str_bool, bool):
-       return str_bool
-    if str_bool.lower() in ('true', 't', 'y', '1'):
-        return True
-    elif str_bool.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        raise ArgumentTypeError('Boolean value expected.')
-
-
 def main(args, extra):
     """
     main entrypoint for running a check. We expect an args object with
@@ -73,23 +53,18 @@ def main(args, extra):
     white_listed_patterns = remove_empty(args.white_listed_patterns.split(","))
     white_listed_files = remove_empty(args.white_listed_files.split(","))
 
-    # parse booleans
-    cleanup = str2bool(args.cleanup)
-    print_all = not str2bool(args.no_print)
-    force_pass = str2bool(args.force_pass)
-
     # Alert user about settings
     print("  original path: %s" % args.path)
     print("     final path: %s" % path)
     print("      subfolder: %s" % args.subfolder)
     print("         branch: %s" % args.branch)
-    print("        cleanup: %s" % cleanup)
+    print("        cleanup: %s" % args.cleanup)
     print("     file types: %s" % file_types)
-    print("      print all: %s" % print_all)
+    print("      print all: %s" % (not args.no_print))
     print(" url whitetlist: %s" % white_listed_urls)
     print("   url patterns: %s" % white_listed_patterns)
     print("  file patterns: %s" % white_listed_files)
-    print("     force pass: %s" % force_pass)
+    print("     force pass: %s" % args.force_pass)
     print("    retry count: %s" % args.retry_count)
     print("           save: %s" % args.save)
     print("        timeout: %s" % args.timeout)
@@ -100,7 +75,7 @@ def main(args, extra):
                                    white_listed_files=white_listed_files,
                                    white_listed_urls=white_listed_urls,
                                    white_listed_patterns=white_listed_patterns,
-                                   print_all=print_all,
+                                   print_all=not args.no_print,
                                    retry_count=args.retry_count,
                                    timeout=args.timeout)
 


### PR DESCRIPTION
This is the final fix to revert back to the working version - a boolean argument going into this function does not need special parsing as a string.

Signed-off-by: vsoch <vsochat@stanford.edu>