### PR TITLE
Adding files flag and fixing bug with return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - bug with incorrect return code on fail, add files flag (0.0.16)
  - reverting back to working client (0.0.15)
  - removing unused file variable (0.0.13)
  - adding support for csv export (0.0.12)

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ for files. In this case, you can use urlchecker check:
 
 ```bash
 $ urlchecker check --help
-
-$ urlchecker check --help
 usage: urlchecker check [-h] [-b BRANCH] [--subfolder SUBFOLDER] [--cleanup]
                         [--force-pass] [--no-print] [--file-types FILE_TYPES]
+                        [--files FILES]
                         [--white-listed-urls WHITE_LISTED_URLS]
                         [--white-listed-patterns WHITE_LISTED_PATTERNS]
                         [--white-listed-files WHITE_LISTED_FILES]
-                        [--retry-count RETRY_COUNT] [--timeout TIMEOUT]
+                        [--save SAVE] [--retry-count RETRY_COUNT]
+                        [--timeout TIMEOUT]
                         path
 
 positional arguments:
@@ -78,6 +78,8 @@ optional arguments:
   --file-types FILE_TYPES
                         comma separated list of file extensions to check
                         (defaults to .md,.py)
+  --files FILES         comma separated list of exact files or patterns to
+                        check.
   --white-listed-urls WHITE_LISTED_URLS
                         comma separated list of white listed urls (no spaces)
   --white-listed-patterns WHITE_LISTED_PATTERNS
@@ -86,6 +88,7 @@ optional arguments:
   --white-listed-files WHITE_LISTED_FILES
                         comma separated list of white listed files and
                         patterns for files (no spaces)
+  --save SAVE           Path to a csv file to save results to.
   --retry-count RETRY_COUNT
                         retry count upon failure (defaults to 2, one retry).
   --timeout TIMEOUT     timeout (seconds) to provide to the requests library

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -16,6 +16,7 @@ import argparse
 import urlchecker
 import logging
 
+
 def get_parser():
     parser = argparse.ArgumentParser(description="urlchecker python")
 
@@ -39,7 +40,7 @@ def get_parser():
     subparsers = parser.add_subparsers(
         help="urlchecker python actions",
         title="actions",
-        description='actions for urlchecker',
+        description="actions for urlchecker",
         dest="command",
     )
 
@@ -55,8 +56,7 @@ def get_parser():
 
     # supports a clone URL or a path
     check.add_argument(
-        "path",
-        help="the local path or GitHub repository to clone and check",
+        "path", help="the local path or GitHub repository to clone and check",
     )
 
     check.add_argument(
@@ -99,7 +99,14 @@ def get_parser():
         default=".md,.py",
     )
 
-# White listing
+    check.add_argument(
+        "--files",
+        dest="files",
+        help="comma separated list of exact files or patterns to check.",
+        default=None,
+    )
+
+    # White listing
 
     check.add_argument(
         "--white-listed-urls",
@@ -119,15 +126,13 @@ def get_parser():
         default="",
     )
 
-# Saving
+    # Saving
 
     check.add_argument(
-        "--save",
-        help="Path toa csv file to save results to.",
-        default=None,
+        "--save", help="Path to a csv file to save results to.", default=None,
     )
 
-# Timeouts
+    # Timeouts
 
     check.add_argument(
         "--retry-count",
@@ -180,7 +185,7 @@ def main():
     else:
         print("Unsupported command %s" % args.command)
         sys.exit(0)
-    
+
     # Pass on to the correct parser
     return_code = 0
     try:

--- a/urlchecker/core/check.py
+++ b/urlchecker/core/check.py
@@ -12,6 +12,7 @@ import sys
 from urlchecker.core import fileproc, urlproc
 from urlchecker.core.whitelist import white_listed
 
+
 def run_urlchecker(
     path,
     file_types,
@@ -19,8 +20,9 @@ def run_urlchecker(
     white_listed_urls,
     white_listed_patterns,
     print_all,
+    include_patterns=None,
     retry_count=2,
-    timeout=5
+    timeout=5,
 ):
     """
     Run the url checker given a path, a whitelist for each of url and file
@@ -34,6 +36,7 @@ def run_urlchecker(
         - white_listed_urls     (list) : list of white-listed urls.
         - white_listed_patterns (list) : list of white-listed patterns for urls.
         - white_listed_files    (list) : list of white-listed files and patterns for flies.
+        - include_patterns      (list) : list of files and patterns to check.
         - retry_count            (int) : number of retries on failed first check. Default=2.
         - timeout                (int) : timeout to use when waiting on check feedback. Default=5.
 
@@ -44,6 +47,7 @@ def run_urlchecker(
 
     # get all file paths
     file_paths = fileproc.get_file_paths(
+        include_patterns=include_patterns,
         base_path=path,
         file_types=file_types,
         white_listed_files=white_listed_files,
@@ -83,7 +87,7 @@ def check_files(
         (list) check-results as a list of two lists (successfull checks, failed checks).
     """
     # init results list (first is success, second is issue)
-    check_results = {"passed":[], "failed": []}
+    check_results = {"passed": [], "failed": []}
 
     # Allow for user to skip specifying white listed options
     white_listed_urls = white_listed_urls or []

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -14,6 +14,7 @@ import requests
 from urlchecker.core import urlmarker
 from urlchecker.logger import print_success, print_failure
 
+
 def record_response(url, response, check_results):
     """
     Record response status of an input url. This function is run after success,

--- a/urlchecker/core/whitelist.py
+++ b/urlchecker/core/whitelist.py
@@ -7,6 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
+
 def white_listed(url, white_listed_urls, white_listed_patterns):
     """
     Check if link is in the white listed URLs or patterns to ignore.

--- a/urlchecker/logger.py
+++ b/urlchecker/logger.py
@@ -9,6 +9,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 import logging
 
+
 def print_failure(message):
     """
     Given a message string, print as a failure in red.
@@ -29,7 +30,7 @@ def print_success(message):
     print("\x1b[32m" + message + "\x1b[0m")
 
 
-def get_logger(name='urlchecker', level=logging.INFO):
+def get_logger(name="urlchecker", level=logging.INFO):
     """
     Get a default logger for the urlchecker library, meaning
     that we use name "urlchecker" and use the default logging
@@ -50,7 +51,9 @@ def get_logger(name='urlchecker', level=logging.INFO):
     ch.setLevel(logging.ERROR)
 
     # formatting
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')    
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     ch.setFormatter(formatter)
     logger.addHandler(ch)
     return logger

--- a/urlchecker/main/github.py
+++ b/urlchecker/main/github.py
@@ -55,7 +55,6 @@ def delete_repo(base_path):
     return result.returncode
 
 
-
 def get_branch(default="master"):
     """
     Derive the selected branch. We first look to the environment variable

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This PR will address the following issues:

 - #27 was introduced as a bug between the now removed versions 0.0.11 through 0.0.15, the force pass boolean is not treated correctly so failing tests are reported as passing.
 - #26 will add a --files argument to allow for specifying files or patterns to include.

There is more work to be done with other issues, but these issues need to be triaged to fix the currently broken library and action.

Signed-off-by: vsoch <vsochat@stanford.edu>