### PR TITLE
Bug/files default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: docker-deploy
 
 on:
-  release:
-    types: [published, created, edited]
+  push:
+    branches:    
+      - master    
 
 jobs:
   testing-docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - default for files needs to be empty string (not None) (0.0.17)
  - bug with incorrect return code on fail, add files flag (0.0.16)
  - reverting back to working client (0.0.15)
  - removing unused file variable (0.0.13)

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -103,7 +103,7 @@ def get_parser():
         "--files",
         dest="files",
         help="comma separated list of exact files or patterns to check.",
-        default=None,
+        default="",
     )
 
     # White listing

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This will fix two issues:

 - a bug that the --files flag default needs to be an empty string 
 - updating the docker build to happen on push to master, since we are being more careful about that now, and I don't have the bandwidth to manage pypi releases and releases on GitHub to trigger the container builds. When a push is done to master to indicate a fix to a version, the container needs to be rebuilt for latest and that version.