### PR TITLE
adding white_listed to results save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Referenced versions in headers are tagged on Github, in parentheses are for pypi
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
  - csv save uses relative paths (0.0.19)
+ - adding white_listed to print of results
  - refactor check.py to be UrlChecker class, save with filename (0.0.18)
  - default for files needs to be empty string (not None) (0.0.17)
  - bug with incorrect return code on fail, add files flag (0.0.16)

--- a/urlchecker/core/check.py
+++ b/urlchecker/core/check.py
@@ -40,7 +40,7 @@ class UrlChecker:
             - include_patterns      (list) : list of files and patterns to check.
         """
         # Initiate results object, and checks lookup (holds UrlCheck) for each file
-        self.results = {"passed": set(), "failed": set()}
+        self.results = {"passed": set(), "failed": set(), "white_listed": set()}
         self.checks = {}
 
         # Save run parameters
@@ -123,8 +123,9 @@ class UrlChecker:
                     else:
                         file_name = os.path.relpath(file_name)
 
-                [writer.writerow([url, "passed", file_name]) for url in result.passed]
                 [writer.writerow([url, "failed", file_name]) for url in result.failed]
+                [writer.writerow([url, "white_listed", file_name]) for url in result.white_listed]
+                [writer.writerow([url, "passed", file_name]) for url in result.passed]
 
         return file_path
 
@@ -174,6 +175,7 @@ class UrlChecker:
             # Update flattened results
             self.results["failed"].update(checker.failed)
             self.results["passed"].update(checker.passed)
+            self.results["white_listed"].update(checker.white_listed)
 
             # Save the checker in the lookup
             self.checks[file_name] = checker


### PR DESCRIPTION
We are currently missing saving of white listed urls to the results file. This small PR will add those to be printed! Here is the example I just ran in test_files:

```bash
 urlchecker check . --save results.csv --white-listed-patterns SuperKogito
```
And you can see that the results file includes white listed for SuperKogito

```
$ cat results.csv 
URL,RESULT,FILENAME
https://github.com/SuperKogito,white_listed,sample_test_file.py
https://github.com/SuperKogito/URLs-checker/README.md,white_listed,sample_test_file.py
https://www.google.com/,passed,sample_test_file.py
https://none.html,failed,sample_test_file.md
https://github.com/SuperKogito/spafe/issues,white_listed,sample_test_file.md
https://github.com/SuperKogito/Voice-based-gender-recognition/issues,white_listed,sample_test_file.md
https://github.com/SuperKogito/spafe/,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/issues,white_listed,sample_test_file.md
https://github.com/SuperKogito/spafe/issues/1,white_listed,sample_test_file.md
https://github.com/SuperKogito/Voice-based-gender-recognition,white_listed,sample_test_file.md
https://github.com/SuperKogito,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/issues/4,white_listed,sample_test_file.md
https://github.com/SuperKogito/Voice-based-gender-recognition/issues/2,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/README.md,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/issues/2,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/issues/3,white_listed,sample_test_file.md
https://github.com/SuperKogito/URLs-checker/blob/master/README.md,white_listed,sample_test_file.md
https://www.google.com/,passed,sample_test_file.md
https://img.shields.io/,passed,sample_test_file.md
```

Signed-off-by: vsoch <vsochat@stanford.edu>