### PR TITLE
Use Travis variable for Codacy token in Travis automation script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ after_success:
   - codecov
   - coveralls
   - coverage xml
-  - export CODACY_PROJECT_TOKEN=d4795dc96ed74f7c8415a2e8c3c42467
+  - export CODACY_PROJECT_TOKEN=$CodacyToken
   - python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
- This PR replaces the old public Codacy token with  a Travis hidden variable including the new token value. 
- The token is defined as an environment variable in Travis, [#defining-variables-in-repository-settings](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
- To see the results in Codacy, use this link: [Codacy/urlchecker-python](https://app.codacy.com/gh/urlstechie/urlchecker-python/dashboard?branch=master)