### PR TITLE
add precommit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,4 @@
   language_version: python3
   minimum_pre_commit_version: 2.9.2
   #require_serial: true
-  #types_or: [python, pyi]
+  types_or: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: urlchecker
   name: urlchecker
   description: "urlchecker-python: test for and report broken links" 
-  entry: urlchecker
+  entry: urlchecker check
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,9 @@
 - id: urlchecker
   name: urlchecker
   description: "urlchecker-python: test for and report broken links" 
-  entry: urlchecker check --files
+  entry: urlchecker check . --file-types "*" --files
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2
-  require_serial: true
+  #require_serial: true
   types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,4 @@
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2
-  #require_serial: true
   types_or: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: urlchecker
+  name: urlchecker
+  description: "urlchecker-python: test for and report broken links" 
+  entry: urlchecker
+  language: python
+  language_version: python3
+  minimum_pre_commit_version: 2.9.2
+  #require_serial: true
+  #types_or: [python, pyi]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: urlchecker
   name: urlchecker
   description: "urlchecker-python: test for and report broken links" 
-  entry: urlchecker check
+  entry: urlchecker check --file-types "*"
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,4 @@
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2
-  #require_serial: true
   types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,4 +5,5 @@
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2
+  #require_serial: true
   types_or: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,9 @@
 - id: urlchecker
   name: urlchecker
   description: "urlchecker-python: test for and report broken links" 
-  entry: urlchecker check --file-types "*"
+  entry: urlchecker check --files
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2
-  #require_serial: true
-  types_or: [text]
+  require_serial: true
+  types: [text]


### PR DESCRIPTION
Fixes https://github.com/urlstechie/urlchecker-python/issues/54.

Issues:
- pre-commit expects to pass a list of files to check. urlchecker expects a directory and patterns.
    - `urlchecker check --file-types "*" --files repositories.json .` still requires path at end
      - SOLVED: argparse will take path anywhere, put it earlier...
- pre-commit controls which files the hook is run on, but urlchecker check wants a list of extensions to look at (in this case it's everything passed). Ideally urlchecker would have an --all option that would look at anything given.
    - Covered by https://github.com/urlstechie/urlchecker-python/pull/47 ? 
      - SOLVED, with `--file-types "*" `

Areas for improvement:
- output is verbose and not the easiest to read

test .pre-commit-config.yaml:
```yaml
repos:
-   repo: https://github.com/aerickson/urlchecker-python
    rev: 046de9cd19134f1648d1904297d4d6514f0e730c
    hooks:
    - id: urlchecker
```

once landed and 0.0.17 has been tagged, the following will work:
```yaml
repos:
-   repo: https://github.com/urlstechie/urlchecker-python
    rev: 0.0.17
    hooks:
    - id: urlchecker
```

example run:
```bash
➜  test_repo git:(main) ✗  pre-commit run -a
urlchecker...............................................................Failed
- hook id: urlchecker
- exit code: 1

original path: .
              final path: /Users/aerickson/git/test_repo
               subfolder: None
                  branch: master
                 cleanup: False
              file types: ['*']
                   files: ['repositories.json']
               print all: True
           urls excluded: []
   url patterns excluded: []
  file patterns excluded: []
              force pass: False
             retry count: 2
                    save: None
                 timeout: 5

 /Users/aerickson/git/test_repo/repositories.json 
 ------------------------------------------------
REDACTED


Done. All URLS passed.
           original path: .
              final path: /Users/aerickson/git/test_repo
               subfolder: None
                  branch: master
                 cleanup: False
              file types: ['*']
                   files: ['test2/blah.txt']
               print all: True
           urls excluded: []
   url patterns excluded: []
  file patterns excluded: []
              force pass: False
             retry count: 2
                    save: None
                 timeout: 5

 /Users/aerickson/git/test_repo/test2/blah.txt 
 ---------------------------------------------
HTTPConnectionPool(host='a.bad.', port=80): Max retries exceeded with url: /link (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10e7a22e0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
http://a.bad./link
HTTPConnectionPool(host='a.bad.', port=80): Max retries exceeded with url: /link (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10e7a2370>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
http://a.bad./link


Done. The following urls did not pass:
http://a.bad./link

➜  test_repo git:(main) ✗  


```

