### PR TITLE
Docker: stretch -> buster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,9 @@ jobs:
           pip install .
           pip install -r tests/test-requirements.txt
           pytest -vs -x --cov=./urlchecker tests/test_*.py
+
+      - name: Test Building container image
+        run: |
+          docker build -t quay.io/urlstechie/urlchecker .
+          DOCKER_TAG=$(docker run quay.io/urlstechie/urlchecker --version)
+          printf "Docker Tag is ${DOCKER_TAG}\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - updating container base to use debian buster and adding certifi (0.0.23)
  - updating "whitelist" arguments to exclude (0.0.22)
  - adding support for dotfiles for a file type (0.0.21)
  - final regexp needs to again parse away { or } (0.0.20)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:buster
 # docker build -t urlschecker .
 WORKDIR /code
 ENV PATH /opt/conda/bin:${PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && \
 COPY . /code
 RUN /bin/bash -c "source activate urlchecker && \
     which python && \
+    which pip && \
+    pip install --upgrade certifi && \
     pip install ."
 RUN echo "source activate urlchecker" > ~/.bashrc
 ENV PATH /opt/conda/envs/urlchecker/bin:${PATH}

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
Ideally, we want to go to bullseye, but minideb does not provide an
image for this yet.

https://hub.docker.com/r/bitnami/minideb

See https://www.debian.org/releases/stretch/:
```
Debian 9 has been superseded by Debian 10 ("buster").
Security updates have been discontinued as of July 6th, 2020.
```


cc @vsoch