### PR TITLE
Add filenames for failed URL checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - adding option to print a summary that contains file names and urls (0.0.24)
  - updating container base to use debian buster and adding certifi (0.0.23)
  - updating "whitelist" arguments to exclude (0.0.22)
  - adding support for dotfiles for a file type (0.0.21)

--- a/tests/test_client_check.py
+++ b/tests/test_client_check.py
@@ -8,10 +8,12 @@ import configparser
 @pytest.mark.parametrize("config_fname", ["./tests/_local_test_config.conf"])
 @pytest.mark.parametrize("cleanup", [False, True])
 @pytest.mark.parametrize("print_all", [False, True])
+@pytest.mark.parametrize("verbose", [False, True])
 @pytest.mark.parametrize("force_pass", [False, True])
 @pytest.mark.parametrize("rcount", [1, 3])
 @pytest.mark.parametrize("timeout", [3, 5])
-def test_client_general(config_fname, cleanup, print_all, force_pass, rcount, timeout):
+def test_client_general(config_fname, cleanup, print_all, verbose,
+                        force_pass, rcount, timeout):
 
     # init config parser
     config = configparser.ConfigParser()
@@ -50,6 +52,8 @@ def test_client_general(config_fname, cleanup, print_all, force_pass, rcount, ti
         cmd.append("--print-all")
     if force_pass:
         cmd.append("--force-pass")
+    if verbose:
+        cmd.append("--verbose")
 
     # Add final path
     cmd.append(path)

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -46,8 +46,7 @@ def get_parser():
 
     # supports a clone URL or a path
     check.add_argument(
-        "path",
-        help="the local path or GitHub repository to clone and check",
+        "path", help="the local path or GitHub repository to clone and check",
     )
 
     check.add_argument(
@@ -87,7 +86,7 @@ def get_parser():
         "--verbose",
         help="Print file names for failed urls in addition to the urls.",
         default=False,
-        action="store_true"
+        action="store_true",
     )
 
     check.add_argument(
@@ -127,9 +126,7 @@ def get_parser():
     # Saving
 
     check.add_argument(
-        "--save",
-        help="Path to a csv file to save results to.",
-        default=None,
+        "--save", help="Path to a csv file to save results to.", default=None,
     )
 
     # Timeouts

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -84,6 +84,13 @@ def get_parser():
     )
 
     check.add_argument(
+        "--verbose",
+        help="Print file names for failed URLs in addition to the URLs.",
+        default=False,
+        action="store_true"
+    )
+
+    check.add_argument(
         "--file-types",
         dest="file_types",
         help="comma separated list of file extensions to check (defaults to .md,.py)",

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -85,7 +85,7 @@ def get_parser():
 
     check.add_argument(
         "--verbose",
-        help="Print file names for failed URLs in addition to the URLs.",
+        help="Print file names for failed urls in addition to the urls.",
         default=False,
         action="store_true"
     )

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -46,7 +46,8 @@ def get_parser():
 
     # supports a clone URL or a path
     check.add_argument(
-        "path", help="the local path or GitHub repository to clone and check",
+        "path",
+        help="the local path or GitHub repository to clone and check",
     )
 
     check.add_argument(
@@ -126,7 +127,9 @@ def get_parser():
     # Saving
 
     check.add_argument(
-        "--save", help="Path to a csv file to save results to.", default=None,
+        "--save",
+        help="Path to a csv file to save results to.",
+        default=None,
     )
 
     # Timeouts

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -103,9 +103,13 @@ def main(args, extra):
     # Case 2: We had errors, print them for the user
     if check_results["failed"]:
         print("\n\nDone. The following urls did not pass:")
-        for file_name, result in checker.checks.items():
-            for url in result.failed:
-                print_failure(url + " (" + file_name + ")")
+        if args.verbose:
+            for file_name, result in checker.checks.items():
+                for url in result.failed:
+                    print_failure(url + " (" + file_name + ")")
+        else:
+            for failed_url in check_results["failed"]:
+                print_failure(failed_url)
 
     # If we have failures and it's not a force pass, exit with 1
     if not args.force_pass and check_results["failed"]:

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -104,7 +104,7 @@ def main(args, extra):
     if check_results["failed"]:
         print("\n\nDone. The following urls did not pass:")
         for file_name, result in checker.checks.items():
-            print_failure(file_name + ' : ' + url for url in result.failed)
+            print_failure(file_name + " : " + url for url in result.failed)
 
     # If we have failures and it's not a force pass, exit with 1
     if not args.force_pass and check_results["failed"]:

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -86,7 +86,7 @@ def main(args, extra):
         timeout=args.timeout,
     )
 
-    # save results to flie, if save indicated
+    # save results to file, if save indicated
     if args.save:
         checker.save_results(args.save)
 
@@ -103,8 +103,8 @@ def main(args, extra):
     # Case 2: We had errors, print them for the user
     if check_results["failed"]:
         print("\n\nDone. The following urls did not pass:")
-        for failed_url in check_results["failed"]:
-            print_failure(failed_url)
+        for file_name, result in checker.checks.items():
+            print_failure(file_name + ' : ' + url for url in result.failed)
 
     # If we have failures and it's not a force pass, exit with 1
     if not args.force_pass and check_results["failed"]:

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -63,6 +63,7 @@ def main(args, extra):
     print("              file types: %s" % file_types)
     print("                   files: %s" % files)
     print("               print all: %s" % (not args.no_print))
+    print("                 verbose: %s" % (args.verbose))
     print("           urls excluded: %s" % exclude_urls)
     print("   url patterns excluded: %s" % exclude_patterns)
     print("  file patterns excluded: %s" % exclude_files)
@@ -97,17 +98,19 @@ def main(args, extra):
 
     # Case 1: We didn't find any urls to check
     if not check_results["failed"] and not check_results["passed"]:
-        print("\n\nDone. No urls were collected.")
+        print("\n\n\U0001F937. No urls were collected.")
         sys.exit(0)
 
     # Case 2: We had errors, print them for the user
     if check_results["failed"]:
-        print("\n\nDone. The following urls did not pass:")
         if args.verbose:
+            print("\n\U0001F914 Uh oh... The following urls did not pass:")
             for file_name, result in checker.checks.items():
+                print_failure(file_name + ":")
                 for url in result.failed:
-                    print_failure(url + " (" + file_name + ")")
+                    print_failure("     " + url)
         else:
+            print("\n\U0001F914 Uh oh... The following urls did not pass:")
             for failed_url in check_results["failed"]:
                 print_failure(failed_url)
 
@@ -117,7 +120,7 @@ def main(args, extra):
 
     # Finally, alert user if we are passing conditionally
     if check_results["failed"]:
-        print("\n\nConditional pass force pass True.")
+        print("\n\U0001F928 Conditional pass force pass True.")
     else:
-        print("\n\nDone. All URLS passed.")
+        print("\n\n\U0001F389 All URLS passed!")
     sys.exit(0)

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -104,7 +104,8 @@ def main(args, extra):
     if check_results["failed"]:
         print("\n\nDone. The following urls did not pass:")
         for file_name, result in checker.checks.items():
-            print_failure(file_name + " : " + url for url in result.failed)
+            for url in result.failed:
+                print_failure(url + " (" + file_name + ")")
 
     # If we have failures and it's not a force pass, exit with 1
     if not args.force_pass and check_results["failed"]:

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
When many files are being checked, it would be useful to see not only the URLs that failed but also the file(s) in which the failure occurred.