### PR TITLE
testing multiprocessing for faster finds!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - multiprocessing to speed up checks (0.0.26)
  - bug fix for verbose option to only print file names that have failures (0.0.25)
  - adding option to print a summary that contains file names and urls (0.0.24)
  - updating container base to use debian buster and adding certifi (0.0.23)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 This is a python module to collect urls over static files (code and documentation)
 and then test for and report broken links. If you are interesting in using
 this as a GitHub action, see [urlchecker-action](https://github.com/urlstechie/urlchecker-action). There are also container
-bases available on [quay.io/urlstechie/urlchecker](https://quay.io/repository/urlstechie/urlchecker?tab=tags).
+bases available on [quay.io/urlstechie/urlchecker](https://quay.io/repository/urlstechie/urlchecker?tab=tags). As of version
+0.0.26, we use multiprocessing so the checks run a lot faster, and you can set `URLCHECKER_WORKERS` to change the number of workers
+(defaults to 9). If you don't want multiprocessing, use version 0.0.25 or earlier.
 
 ## Module Documentation
 

--- a/docs/source/fileproc.rst
+++ b/docs/source/fileproc.rst
@@ -1,5 +1,5 @@
 urlchecker.core.fileproc
-==========================
+========================
 
 
 .. automodule:: urlchecker.core.fileproc

--- a/urlchecker/__init__.py
+++ b/urlchecker/__init__.py
@@ -1,10 +1,3 @@
-"""
-
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
-
-This source code is licensed under the terms of the MIT license.  
-For a copy, see <https://opensource.org/licenses/MIT>.
-
-"""
-
 from urlchecker.version import __version__
+
+assert __version__

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -2,7 +2,7 @@
 
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -1,6 +1,6 @@
 """
 client/github.py: entrypoint for interaction with a GitHub repostiory.
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 """
 
 import re
@@ -106,9 +106,9 @@ def main(args, extra):
         if args.verbose:
             print("\n\U0001F914 Uh oh... The following urls did not pass:")
             for file_name, result in checker.checks.items():
-                if result.failed:
+                if result["failed"]:
                     print_failure(file_name + ":")
-                    for url in result.failed:
+                    for url in result["failed"]:
                         print_failure("     " + url)
         else:
             print("\n\U0001F914 Uh oh... The following urls did not pass:")

--- a/urlchecker/core/exclude.py
+++ b/urlchecker/core/exclude.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/core/fileproc.py
+++ b/urlchecker/core/fileproc.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/core/urlmarker.py
+++ b/urlchecker/core/urlmarker.py
@@ -4,7 +4,7 @@ The web url matching regex used by markdown
 http://daringfireball.net/2010/07/improved_regex_for_matching_urls
 https://gist.github.com/gruber/8891611
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.  
 For a copy, see <https://opensource.org/licenses/MIT>.
@@ -168,13 +168,8 @@ class UrlCheckResult:
         # if no urls are found, mention it if required
         if not urls:
             if self.print_all:
-                if self.file_name:
-                    print("\n", self.file_name, "\n", "-" * len(self.file_name))
                 print("No urls found.")
             return
-
-        if self.file_name:
-            print("\n", self.file_name, "\n", "-" * len(self.file_name))
 
         # init seen urls list
         seen = set()

--- a/urlchecker/core/worker.py
+++ b/urlchecker/core/worker.py
@@ -1,0 +1,110 @@
+"""
+
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
+
+This source code is licensed under the terms of the MIT license.  
+For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+
+import itertools
+import multiprocessing
+import os
+import time
+import signal
+import sys
+
+from urlchecker.logger import get_logger
+
+logger = get_logger()
+
+
+class Workers:
+    def __init__(self, workers=None):
+
+        if workers is None:
+            workers = int(os.environ.get("URLCHECKER_WORKERS", 9))
+        self.workers = workers
+        logger.debug(f"Using {self.workers} workers for multiprocess.")
+
+    def start(self):
+        logger.debug("Starting multiprocess")
+        self.start_time = time.time()
+
+    def end(self):
+        self.end_time = time.time()
+        self.runtime = self.runtime = self.end_time - self.start_time
+        logger.debug(f"Ending multiprocess, runtime: {self.runtime} sec")
+
+    def run(self, funcs, tasks):
+        """run will send a list of tasks, a tuple with arguments, through a function.
+        the arguments should be ordered correctly.
+
+        Parameters
+        ==========
+        funcs: the functions to run with multiprocessing.pool, a dictionary
+               with lookup by the task name
+        tasks: a dict of tasks, each task name (key) with a
+               tuple of arguments to process
+        """
+        # Number of tasks must == number of functions
+        assert len(funcs) == len(tasks)
+
+        # Keep track of some progress for the user
+        progress = 1
+
+        # if we don't have tasks, don't run
+        if not tasks:
+            return
+
+        # results will also have the same key to look up
+        finished = dict()
+        results = []
+
+        try:
+            pool = multiprocessing.Pool(self.workers, init_worker)
+
+            self.start()
+            for key, params in tasks.items():
+                func = funcs[key]
+                logger.info("Processing task %s:%s" % (key, params))
+                result = pool.apply_async(multi_wrapper, multi_package(func, [params]))
+
+                # Store the key with the result
+                results.append((key, result))
+
+            while len(results) > 0:
+                pair = results.pop()
+                key, result = pair
+                result.wait()
+                progress += 1
+                finished[key] = result.get()
+
+            self.end()
+            pool.close()
+            pool.join()
+
+        except (KeyboardInterrupt, SystemExit):
+            logger.error("Keyboard interrupt detected, terminating workers!")
+            pool.terminate()
+            sys.exit(1)
+
+        except:
+            logger.exit("Error running task.")
+
+        return finished
+
+
+# Supporting functions for MultiProcess Worker
+def init_worker():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def multi_wrapper(func_args):
+    function, kwargs = func_args
+    return function(**kwargs)
+
+
+def multi_package(func, kwargs):
+    zipped = zip(itertools.repeat(func), kwargs)
+    return zipped

--- a/urlchecker/core/worker.py
+++ b/urlchecker/core/worker.py
@@ -67,7 +67,6 @@ class Workers:
             self.start()
             for key, params in tasks.items():
                 func = funcs[key]
-                logger.info("Processing task %s:%s" % (key, params))
                 result = pool.apply_async(multi_wrapper, multi_package(func, [params]))
 
                 # Store the key with the result
@@ -90,7 +89,7 @@ class Workers:
             sys.exit(1)
 
         except:
-            logger.exit("Error running task.")
+            logger.exit("Error running task")
 
         return finished
 

--- a/urlchecker/logger.py
+++ b/urlchecker/logger.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.  
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/main/github.py
+++ b/urlchecker/main/github.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.  
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/main/utils.py
+++ b/urlchecker/main/utils.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.  
 For a copy, see <https://opensource.org/licenses/MIT>.

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -1,13 +1,13 @@
 """
 
-Copyright (c) 2020-2021 Ayoub Malek and Vanessa Sochat
+Copyright (c) 2020-2022 Ayoub Malek and Vanessa Sochat
 
 This source code is licensed under the terms of the MIT license.
 For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This might be a terrible idea, but in repos where we have a LOT of files to check, it's getting much slower to do the check. So here I'm going to test using multiprocessing, meaning we can check ~9 files in parallel. I'll try to open a custom action branch so I can test this on a repo I know is rather large (given it passes here of course!).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>