### PR TITLE
testing adding support for unique urls between urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - ensure duplicated URLs are not checked across workers (0.0.27)
  - multiprocessing to speed up checks (0.0.26)
  - bug fix for verbose option to only print file names that have failures (0.0.25)
  - adding option to print a summary that contains file names and urls (0.0.24)

--- a/tests/test_client_check.py
+++ b/tests/test_client_check.py
@@ -12,8 +12,9 @@ import configparser
 @pytest.mark.parametrize("force_pass", [False, True])
 @pytest.mark.parametrize("rcount", [1, 3])
 @pytest.mark.parametrize("timeout", [3, 5])
-def test_client_general(config_fname, cleanup, print_all, verbose,
-                        force_pass, rcount, timeout):
+def test_client_general(
+    config_fname, cleanup, print_all, verbose, force_pass, rcount, timeout
+):
 
     # init config parser
     config = configparser.ConfigParser()
@@ -59,7 +60,7 @@ def test_client_general(config_fname, cleanup, print_all, verbose,
     cmd.append(path)
 
     # excute script
-    pipe = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 @pytest.mark.parametrize("save", [True])
@@ -101,7 +102,7 @@ def test_client_save(save):
 
     print(" ".join(cmd))
     # excute script
-    pipe = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if save:
         if not os.path.exists(output_csv.name):
             raise AssertionError

--- a/tests/test_core_check.py
+++ b/tests/test_core_check.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import pytest
 import configparser
 from urlchecker.core.fileproc import get_file_paths
@@ -78,7 +77,6 @@ def test_check_run_save(tmp_path, retry_count):
     ]
     exclude_patterns = ["https://superkogito.github.io/tables"]
     timeout = 1
-    force_pass = False
 
     # clone repo
     base_path = clone_repo(git_path)
@@ -89,7 +87,7 @@ def test_check_run_save(tmp_path, retry_count):
 
     # check repo urls
     checker = UrlChecker(print_all=print_all)
-    check_results = checker.run(
+    checker.run(
         file_paths=file_paths,
         exclude_urls=exclude_urls,
         exclude_patterns=exclude_patterns,

--- a/tests/test_core_exclude.py
+++ b/tests/test_core_exclude.py
@@ -1,4 +1,3 @@
-import pytest
 from urlchecker.core.exclude import excluded
 
 

--- a/tests/test_core_fileproc.py
+++ b/tests/test_core_fileproc.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 from urlchecker.core.fileproc import (
     check_file_type,
     get_file_paths,
@@ -15,7 +14,7 @@ from urlchecker.core.fileproc import (
     [".filename"],
 )
 @pytest.mark.parametrize("file_types", [[".*"]])
-def test_check_file_type(file_path, file_types):
+def test_check_all_file_type(file_path, file_types):
     """
     test pattern matching
     """
@@ -106,13 +105,13 @@ def test_get_file_paths(base_path, file_types):
     "file_path",
     ["tests/test_files/sample_test_file.md", "tests/test_files/sample_test_file.md"],
 )
-def collect_links_from_file(file_path):
+def test_collect_links_from_file(file_path):
     """
     test links collerction function.
     """
     # read file content
     urls = collect_links_from_file()
-    assert len(url) == 3
+    assert len(urls) == 3
 
 
 def test_remove_empty():

--- a/tests/test_core_fileproc.py
+++ b/tests/test_core_fileproc.py
@@ -111,7 +111,7 @@ def test_collect_links_from_file(file_path):
     """
     # read file content
     urls = collect_links_from_file(file_path)
-    assert len(urls) == 3
+    assert len(urls) == 17
 
 
 def test_remove_empty():

--- a/tests/test_core_fileproc.py
+++ b/tests/test_core_fileproc.py
@@ -110,7 +110,7 @@ def test_collect_links_from_file(file_path):
     test links collerction function.
     """
     # read file content
-    urls = collect_links_from_file()
+    urls = collect_links_from_file(file_path)
     assert len(urls) == 3
 
 

--- a/tests/test_core_urlproc.py
+++ b/tests/test_core_urlproc.py
@@ -2,20 +2,43 @@ import pytest
 from urlchecker.core.fileproc import collect_links_from_file
 from urlchecker.core.urlproc import (
     UrlCheckResult,
+    find_urls,
     get_user_agent,
     check_response_status_code,
 )
 
 
 @pytest.mark.parametrize(
-    "file",
+    "files",
+    [
+        [
+            "tests/test_files/sample_test_file.md",
+            "tests/test_files/sample_test_file.py",
+            "tests/test_files/sample_test_file.rst",
+        ]
+    ],
+)
+def test_no_duplicates(files):
+    """
+    Ensure when we provide a list of files (with redundant urls) we don't
+    see duplicates when using find_urls
+    """
+    seen = set()
+    for _, urls in find_urls(files):
+        for url in urls:
+            assert url not in seen
+        [seen.add(url) for url in urls]
+
+
+@pytest.mark.parametrize(
+    "filename",
     ["tests/test_files/sample_test_file.md"],
 )
-def test_check_urls(file):
+def test_check_urls(filename):
     """
     test check urls check function.
     """
-    urls = collect_links_from_file(file)
+    urls = collect_links_from_file(filename)
     checker = UrlCheckResult()
     assert str(checker) == "UrlCheckResult"
 

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from urlchecker.main.utils import get_tmpdir
 
 

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -166,7 +166,22 @@ class UrlCheckResult:
             return
 
         # collect all links from file (unique=True is set)
-        self.urls = fileproc.collect_links_from_file(self.file_name)
+        urls = fileproc.collect_links_from_file(self.file_name)
+
+        # eliminate excluded urls and patterns
+        if self.exclude_urls or self.exclude_patterns:
+            self.excluded = [
+                url
+                for url in urls
+                if excluded(url, self.exclude_urls, self.exclude_patterns)
+            ]
+            urls = list(set(urls).difference(set(self.excluded)))
+
+        self.urls = urls
+
+        # if no urls are found, mention it if required
+        if not self.urls and self.print_all:
+            print("No urls found.")
 
     @property
     def all(self):
@@ -188,21 +203,6 @@ class UrlCheckResult:
             - timeout        (int) : a timeout in seconds for blocking operations like the connection attempt.
         """
         urls = urls or self.urls
-
-        # eliminate excluded urls and patterns
-        if self.exclude_urls or self.exclude_patterns:
-            self.excluded = [
-                url
-                for url in urls
-                if excluded(url, self.exclude_urls, self.exclude_patterns)
-            ]
-            urls = list(set(urls).difference(set(self.excluded)))
-
-        # if no urls are found, mention it if required
-        if not urls:
-            if self.print_all:
-                print("No urls found.")
-            return
 
         # init seen urls list
         seen = set()

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -179,10 +179,6 @@ class UrlCheckResult:
 
         self.urls = urls
 
-        # if no urls are found, mention it if required
-        if not self.urls and self.print_all:
-            print("No urls found.")
-
     @property
     def all(self):
         """All returns all urls found in a file name, including those that

--- a/urlchecker/core/worker.py
+++ b/urlchecker/core/worker.py
@@ -89,7 +89,7 @@ class Workers:
             sys.exit(1)
 
         except:
-            logger.exit("Error running task")
+            logger.error("Error running task")
 
         return finished
 

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
right now duplicate urls in file (each run by a separate worker) will be run twice.
We can improve upon this by doing the extraction of URLs first, and only adding a url
to a new checker list given that it has not been seen before. This is supported by
adding an optional urls variable to the UrlCheckResult, and only if not defined do we
parse the file. This allows us to parse on a first pass, update with unique urls,
and then hand those urls directly to the worker instance to check

Signed-off-by: vsoch <vsoch@users.noreply.github.com>