### PR TITLE
ensure we do not fail if no urls to check to close #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - don't exit and fail if no URLs to check (0.0.27)
  - multiprocessing to speed up checks (0.0.26)
  - bug fix for verbose option to only print file names that have failures (0.0.25)
  - adding option to print a summary that contains file names and urls (0.0.24)

--- a/urlchecker/core/check.py
+++ b/urlchecker/core/check.py
@@ -190,6 +190,10 @@ class UrlChecker:
             funcs[file_name] = check_task
 
         results = workers.run(funcs, tasks)
+        if not results:
+            print("\U0001F914 There were no URLs to check.")
+            sys.exit(0)
+
         for file_name, result in results.items():
             self.checks[file_name] = result
             self.results["failed"].update(result["failed"])

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
This does a check if results is None (meaning no tasks ran) and then exits with 0 if no urls to check, e.g.,:

```bash
$ urlchecker check --branch master --no-print --file-types .md,.py,.rst,.html --exclude-urls https://en.w,https://github.com/bssw-tutorial/presentations/blob/master,https://doi.org/10.1126/science.aah6168,https://doi.org/10.1002/spe.2220 --retry-count 1 --timeout 5 --files .github/workflows/main.yml  .
           original path: .
              final path: /home/vanessa/Desktop/Code/urlchecker-python
               subfolder: None
                  branch: master
                 cleanup: False
              file types: ['.md', '.py', '.rst', '.html']
                   files: ['.github/workflows/main.yml']
               print all: False
                 verbose: False
           urls excluded: ['https://en.w', 'https://github.com/bssw-tutorial/presentations/blob/master', 'https://doi.org/10.1126/science.aah6168', 'https://doi.org/10.1002/spe.2220']
   url patterns excluded: []
  file patterns excluded: []
              force pass: False
             retry count: 1
                    save: None
                 timeout: 5
🤔 There were no URLs to check.
```
Signed-off-by: vsoch <vsoch@users.noreply.github.com>