### PR TITLE
adding support for serial and fixing bug that driver might not be defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - serial option for debugging (0.0.32)
  - adding support for web driver for harder URLs (0.0.31)
  - use ANSI escape sequences for colors, fake-useragent for agents (0.0.30)
  - adding type hints to code, more tests and logging bug fix (0.0.29)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,12 @@ urlchecker check --file-types ".*,*.html" .
 
 **Note that while some patterns will work without quotes, it's recommended for most**
 to use them because if the shell expands any part of the pattern, it will not work as
-expected. By default, the urlchecker checks python and markdown.
+expected. By default, the urlchecker checks python and markdown. If a multiprocessing workers has an error,
+you can also add `--serial` to run in serial and test. The run will be slower, but it's useful for debugging.
+
+```bash
+$ urlchecker check . --files "content/docs/hacking/contributing/documentation/index.md" --serial
+```
 
 ### Check GitHub Repository
 

--- a/urlchecker/client/__init__.py
+++ b/urlchecker/client/__init__.py
@@ -71,6 +71,12 @@ def get_parser():
     )
 
     check.add_argument(
+        "--serial",
+        help="run checks in serial (no multiprocess)",
+        default=False,
+        action="store_true",
+    )
+    check.add_argument(
         "--force-pass",
         help="force successful pass (return code 0) regardless of result",
         default=False,

--- a/urlchecker/client/check.py
+++ b/urlchecker/client/check.py
@@ -65,6 +65,7 @@ def main(args, extra):
     print("               subfolder: %s" % args.subfolder)
     print("                  branch: %s" % args.branch)
     print("                 cleanup: %s" % args.cleanup)
+    print("                  serial: %s" % args.serial)
     print("              file types: %s" % file_types)
     print("                   files: %s" % files)
     print("               print all: %s" % (not args.no_print))
@@ -84,6 +85,7 @@ def main(args, extra):
         include_patterns=files,
         exclude_files=exclude_files,
         print_all=not args.no_print,
+        serial=args.serial,
     )
     check_results = checker.run(
         exclude_urls=exclude_urls,

--- a/urlchecker/core/check.py
+++ b/urlchecker/core/check.py
@@ -221,7 +221,7 @@ class UrlChecker:
             funcs[file_name] = check_task
 
         if not self.serial:
-            results = workers.run(funcs, tasks)
+            results = workers.run(funcs, tasks)  # type: ignore
         if not results:
             print("\U0001F914 There were no URLs to check.")
             sys.exit(0)

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -242,7 +242,7 @@ class UrlCheckResult:
 
                 # Web driver doesn't have same issues with ssl
                 except Exception as e:
-                    if driver.check(url):
+                    if driver and driver.check(url):
                         response = requests.Response()
                         response.status_code = 200
                     else:

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
To test, you can do both:

```bash
$ urlchecker check . --files "content/docs/hacking/contributing/documentation/index.md"
```
and

```bash
$ urlchecker check . --files "content/docs/hacking/contributing/documentation/index.md" --serial
```

Signed-off-by: vsoch <vsochat@stanford.edu>