### PR TITLE
Return driver object only when valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/urlstechie/urlschecker-python/tree/master) (master)
+ - avoid using web driver when it doesn't work (0.0.36)
  - allow variable to skip checking certificates (0.0.35)
  - switch back to pypi release of fake-useragent (0.0.34)
  - preparing to install from git for fake-useragent (0.0.33)

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -153,12 +153,12 @@ class UrlCheckResult:
         try:
             from .webdriver import WebDriver
 
-            default_driver = WebDriver(port=port, timeout=timeout)
+            driver = WebDriver(port=port, timeout=timeout)
 
             # Do a sanity check of the default driver
-            default_driver.check("https://google.com")
-            driver = default_driver
+            driver.check("https://google.com")
         except:
+            driver = None
             logger.warning(
                 "Issue with driver, results will be improved if you have it! Please match your version from https://googlechromelabs.github.io/chrome-for-testing"
             )

--- a/urlchecker/core/urlproc.py
+++ b/urlchecker/core/urlproc.py
@@ -153,10 +153,11 @@ class UrlCheckResult:
         try:
             from .webdriver import WebDriver
 
-            driver = WebDriver(port=port, timeout=timeout)
+            default_driver = WebDriver(port=port, timeout=timeout)
 
-            # Do a sanity check of the driver
-            driver.check("https://google.com")
+            # Do a sanity check of the default driver
+            default_driver.check("https://google.com")
+            driver = default_driver
         except:
             logger.warning(
                 "Issue with driver, results will be improved if you have it! Please match your version from https://googlechromelabs.github.io/chrome-for-testing"

--- a/urlchecker/version.py
+++ b/urlchecker/version.py
@@ -7,7 +7,7 @@ For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
 
-__version__ = "0.0.35"
+__version__ = "0.0.36"
 AUTHOR = "Ayoub Malek, Vanessa Sochat"
 AUTHOR_EMAIL = "superkogito@gmail.com, vsochat@stanford.edu"
 NAME = "urlchecker"


### PR DESCRIPTION
Without this, a driver that failed the sanity check could be returned. This leads to attempting to use it when checking URLs, which led to avoidable failures.

Fixes #92